### PR TITLE
Add J1 Labs to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @jupiterone/sre @jupiterone/integrations @jupiterone/security @chasen-bettinger @erichs
+* @jupiterone/sre @jupiterone/integrations @jupiterone/security @jupiterone/j1-labs
 
 CODEOWNERS @jupiterone/security

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @jupiterone/sre @jupiterone/integrations @jupiterone/security
+* @jupiterone/sre @jupiterone/integrations @jupiterone/security @chasen-bettinger @erichs
 
 CODEOWNERS @jupiterone/security


### PR DESCRIPTION
As J1 Labs build out Jetpack, we would like to contribute reusable code as it relates to JupiterOne within our Go SDK.